### PR TITLE
ci: Fix broken NuGet build workflow.

### DIFF
--- a/.github/workflows/publish_nuget_pkg.yaml
+++ b/.github/workflows/publish_nuget_pkg.yaml
@@ -23,8 +23,10 @@ jobs:
         with:
           fetch-depth: 0 # Get all history for automatic versioning
 
-      - name: Setup .NET
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
 
       - name: Restore dependencies
         run: dotnet restore


### PR DESCRIPTION
## What changed?

The NuGet builds fail for some inscrutable reasons around setting up the .NET environment. This PR is hopefully a fix for that issue.