### PR TITLE
ci: Add manual override for NuGet publishing.

### DIFF
--- a/.github/workflows/publish_nuget_pkg.yaml
+++ b/.github/workflows/publish_nuget_pkg.yaml
@@ -7,6 +7,11 @@ on:
       - "main"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      force_publish:
+        description: "Ignore checks and attempt to publish to NuGet."
+        type: boolean
+        default: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -39,6 +44,7 @@ jobs:
 
       - name: Get latest version from NuGet
         id: nuget_version
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.force_publish == 'false' }}
         run: |
           $latestVersion = (Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/styra.ucast.linq/index.json" | ConvertFrom-Json).versions[-1]
           echo "LATEST_VERSION=$latestVersion" >> $env:GITHUB_OUTPUT
@@ -55,7 +61,7 @@ jobs:
         run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
 
       - name: Publish NuGet package
-        if: steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION
+        if: ${{ (steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION) || inputs.force_publish == 'true' }}
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
             dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What changed?

This PR adds a manual override option for NuGet package publishing, which we need in order to publish the *first* version of the package.