### PR TITLE
ci: Fix manual override for publish to NuGet.

### DIFF
--- a/.github/workflows/publish_nuget_pkg.yaml
+++ b/.github/workflows/publish_nuget_pkg.yaml
@@ -61,7 +61,15 @@ jobs:
         run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
 
       - name: Publish NuGet package
-        if: ${{ (steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION) || inputs.force_publish == 'true' }}
+        if: ${{ inputs.force_publish != 'true' && steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION }}
+        run: |
+          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
+            dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }
+        shell: pwsh
+
+      - name: Force Publish NuGet package
+        if: ${{ inputs.force_publish == 'true' }}
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
             dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What changed?

More bugfixing for the accursed Github Actions workflows.