### PR TITLE
src: Fix broken package naming. Purge remaining OPA references.

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   publish-docs:
     env:
-      STYRA_GH_PAGES_URL: https://styrainc.github.io/opa-csharp
+      STYRA_GH_PAGES_URL: https://styrainc.github.io/ucast-linq
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish_gh_release.yaml
+++ b/.github/workflows/publish_gh_release.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           VERSION: ${{ steps.current_version.outputs.CURRENT_VERSION }}
 
-      - name: Create Styra.Opa.AspNetCore GH release
+      - name: Create Styra.Ucast.Linq GH release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}

--- a/src/Styra.Ucast.Linq/Styra.Ucast.Linq.csproj
+++ b/src/Styra.Ucast.Linq/Styra.Ucast.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <PackageId>Styra.Opa</PackageId>
+    <PackageId>Styra.Ucast.Linq</PackageId>
     <Version>0.1.0</Version>
     <Authors>Styra</Authors>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
## What changed?

Here in part 5 of the saga, we're hopefully going to finally get this right, and publish the NuGet package to the correct destination. :man_facepalming: 