### PR TITLE
ci: Re-enable normal NuGet publishing checks.

### DIFF
--- a/.github/workflows/publish_nuget_pkg.yaml
+++ b/.github/workflows/publish_nuget_pkg.yaml
@@ -37,12 +37,12 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
 
-      # - name: Get latest version from NuGet
-      #   id: nuget_version
-      #   run: |
-      #     $latestVersion = (Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/styra.ucast.linq/index.json" | ConvertFrom-Json).versions[-1]
-      #     echo "LATEST_VERSION=$latestVersion" >> $env:GITHUB_OUTPUT
-      #   shell: pwsh
+      - name: Get latest version from NuGet
+        id: nuget_version
+        run: |
+          $latestVersion = (Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/styra.ucast.linq/index.json" | ConvertFrom-Json).versions[-1]
+          echo "LATEST_VERSION=$latestVersion" >> $env:GITHUB_OUTPUT
+        shell: pwsh
 
       - name: Get current version
         id: current_version
@@ -55,7 +55,7 @@ jobs:
         run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
 
       - name: Publish NuGet package
-        #if: ${{ steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION }}
+        if: ${{ steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION }}
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
             dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What changed?

We successfully got the first package version up onto NuGet. Now, we can put back the original version guards.