### PR TITLE
src: Add initial data masking support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.2.0
+
+This release includes numerous small cleanups and refactors, and adds initial support for column masking of datasets!
+
+### Column masking
+
+To mask a particular field out of a collection, there is a new `EnumerableExtensions.MaskElements<T>` method, which takes a collection, a Dictionary of column masking rules, and a `MappingConfiguration`, and produces a shallow-cloned copy of the collection where every object's fields have been masked according to the masking rules.
+
+### Breaking changes
+
+The `Dictionary<string, Func<ParameterExpression, Expression>>` type used for LINQ mappings has been switched out for a more powerful `MappingConfiguration` class, which allows reusing the name mappings for both data filtering, and column masking.
+
 
 ## 0.1.0
 
-This releases is an release engineering tests, aimed at sorting out automated publishing of a Github Release and NuGet package.
+This release is an release engineering tests, aimed at sorting out automated publishing of a Github Release and NuGet package.

--- a/src/Styra.Ucast.Linq/EnumerableExtensions.cs
+++ b/src/Styra.Ucast.Linq/EnumerableExtensions.cs
@@ -7,7 +7,15 @@ namespace Styra.Ucast.Linq;
 
 public static class EnumerableExtension
 {
-    public static T ShallowClone<T>(T source)
+    /// <summary>
+    /// Allows shallow cloning an object without requiring serializing and
+    /// deserializing the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the source object.</typeparam>
+    /// <param name="source">The object to clone.</param>
+    /// <returns>A shallow clone of the source object.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    private static T ShallowClone<T>(T source)
     {
         if (source == null) return default!; // Don't care, currently.
 
@@ -41,6 +49,15 @@ public static class EnumerableExtension
 
         throw new ArgumentException($"Unable to clone type {type.Name}");
     }
+
+    /// <summary>
+    /// Mask fields on a single object. This is how individual objects are masked in a collection.
+    /// </summary>
+    /// <typeparam name="T">The type of the source object.</typeparam>
+    /// <param name="source">The object whose fields will be masked.</param>
+    /// <param name="maskingRules">A dictionary mapping UCAST field names to column masking functions.</param>
+    /// <param name="config">A name mapping config, allowing easy translation of UCAST field names to object fields.</param>
+    /// <returns>A shallow clone of the source object, with all masks applied.</returns>
     private static T MaskElement<T>(this T source, Dictionary<string, MaskingFunc> maskingRules, MappingConfiguration<T> config)
     {
         T result = ShallowClone(source);
@@ -58,6 +75,14 @@ public static class EnumerableExtension
         return result;
     }
 
+    /// <summary>
+    /// Masks fields on every element in a collection, using a Dictionary of masks, and a name mapping.
+    /// </summary>
+    /// <typeparam name="T">The type of the source collection's elements.</typeparam>
+    /// <param name="source">The collection whose elements' fields will be masked.</param>
+    /// <param name="maskingRules">A dictionary mapping UCAST field names to column masking functions.</param>
+    /// <param name="config">A name mapping config, allowing easy translation of UCAST field names to object fields.</param>
+    /// <returns>A new collection, containing shallow clones of the source collection's object, with all masks applied to each object.</returns>
     public static IEnumerable<T> MaskElements<T>(this IEnumerable<T> source, Dictionary<string, MaskingFunc>? maskingRules, MappingConfiguration<T> config)
     {
         if (maskingRules is null)

--- a/src/Styra.Ucast.Linq/EnumerableExtensions.cs
+++ b/src/Styra.Ucast.Linq/EnumerableExtensions.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Styra.Ucast.Linq;
+
+public static class EnumerableExtension
+{
+    public static T ShallowClone<T>(T source)
+    {
+        if (source == null) return default!; // Don't care, currently.
+
+        Type type = typeof(T);
+
+        // Handle primitive types and strings.
+        if (type.IsPrimitive || type == typeof(string))
+        {
+            return source;
+        }
+
+        // Handle reference types.
+        if (type.IsClass)
+        {
+            object clone = Activator.CreateInstance(type)!; // Should never be null by this point.
+            FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            foreach (FieldInfo field in fields)
+            {
+                field.SetValue(clone, field.GetValue(source));
+            }
+
+            return (T)clone;
+        }
+
+        // Handle value types (structs).
+        if (type.IsValueType)
+        {
+            return source;
+        }
+
+        throw new ArgumentException($"Unable to clone type {type.Name}");
+    }
+    private static T MaskElement<T>(this T source, Dictionary<string, MaskingFunc> maskingRules, MappingConfiguration<T> config)
+    {
+        T result = ShallowClone(source);
+        foreach (var kv in maskingRules)
+        {
+            var name = kv.Key;
+            var maskingFunc = kv.Value;
+            // Future: Plug this value into masking functions that use the original column's value, (e.g. hash functions).
+            // var currentValue = config.GetPropertyByName(name, result);
+            if (maskingFunc.Replace is not null)
+            {
+                config.SetPropertyByName(name, ref result, maskingFunc.Replace?.Value);
+            }
+        }
+        return result;
+    }
+
+    public static IEnumerable<T> MaskElements<T>(this IEnumerable<T> source, Dictionary<string, MaskingFunc>? maskingRules, MappingConfiguration<T> config)
+    {
+        if (maskingRules is null)
+        {
+            return source;
+        }
+        IEnumerable<T> result = source.Select(x => x.MaskElement(maskingRules, config));
+        return result;
+    }
+}

--- a/src/Styra.Ucast.Linq/MappingConfiguration.cs
+++ b/src/Styra.Ucast.Linq/MappingConfiguration.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Styra.Ucast.Linq;
+
+public class NameToLINQExpressionConfiguration : Dictionary<string, Func<ParameterExpression, Expression>>;
+
+/// <summary>
+/// This type helps wrap up the complexities of building LINQ expressions filtering, and for generating dynamic property lookups.
+/// </summary>
+/// <typeparam name="T">The type to build a name mapping config over.</typeparam>
+public class MappingConfiguration<T>
+{
+    // Cache of generated mappings, so we don't have to reconstruct them every time.
+    protected Dictionary<string, string> nameMappings = new(typeof(T).GetProperties().Length);
+    protected Dictionary<string, Func<ParameterExpression, Expression>> linqMappingsCache = new(typeof(T).GetProperties().Length);
+    protected string namePrefix = typeof(T).Name.ToLower();
+
+    /// <summary>
+    ///   <para>
+    ///   Constructs a MappingConfiguration object that maps UCAST
+    ///   property names to lambda functions.<br />
+    ///   The lambda functions allow late-binding a LINQ data source into LINQ
+    ///   Property expression lookups, which are used extensively when building
+    ///   conditions over EF Core models.
+    ///   </para>
+    ///   <para>
+    ///   When deciding on names for data source properties, we follow a small set
+    ///   of default construction rules:
+    ///   <list type="bullet">
+    ///    <item>Example.Id -> "example.id"</item>
+    ///    <item>Example.LastUpdated -> "example.last_updated"</item>
+    ///   </list>
+    ///   </para>
+    /// </summary>
+    /// <param name="namesToProperties">A dictionary, mapping UCAST field names to property lookups in the object.</param>
+    /// <param name="prefix">Name of the LINQ data source, as it will appear in UCAST field references. Used as a prefix for the generated property mappings.</param>
+    public MappingConfiguration(Dictionary<string, string>? namesToProperties = null, string? prefix = null)
+    {
+        namePrefix = prefix ?? namePrefix;
+        foreach (var property in typeof(T).GetProperties())
+        {
+            var snakeCasedProperty = property.Name.ToSnakeCase();
+            snakeCasedProperty = string.IsNullOrEmpty(namePrefix) ? snakeCasedProperty : $"{namePrefix}.{snakeCasedProperty}";
+            nameMappings[snakeCasedProperty] = property.Name;
+            linqMappingsCache[snakeCasedProperty] = param => Expression.Property(param, property.Name);
+        }
+        if (namesToProperties is not null)
+        {
+            foreach (var mapping in namesToProperties)
+            {
+                // Split string on '.' characters, and build out the Expression.Property() chain accordingly.
+                var parts = mapping.Value.Split('.');
+                var startIdx = parts[0] == prefix ? 0 : 1;
+                linqMappingsCache[mapping.Key] = param => Expression.Property(param, parts[startIdx]);
+                for (var i = startIdx + 1; i < parts.Length; i++)
+                {
+                    var part = parts[i];
+                    linqMappingsCache[mapping.Key] = param => Expression.Property(linqMappingsCache[mapping.Key](param), part);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns all stored UCAST to LINQ mappings.
+    /// </summary>
+    /// <returns>
+    /// A dictionary where the keys are UCAST field names, and the values are LINQ lambdas.
+    /// </returns>
+    public Dictionary<string, Func<ParameterExpression, Expression>> GetLinqMappings()
+    {
+        return new(linqMappingsCache);
+    }
+
+    /// <summary>
+    /// Retrieves an object property dynamically, given the UCAST field name.
+    /// </summary>
+    /// <returns>
+    /// The value stored in the field, or else null.
+    /// </returns>
+    /// <remarks>
+    /// Uses reflection, so this method may be very slow.
+    /// </remarks>
+    public object? GetPropertyByName(string name, ref T source)
+    {
+        if (source is not null && nameMappings.TryGetValue(name, out var accessor))
+        {
+            return source.GetType().GetProperty(accessor)?.GetValue(source);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Sets an object property dynamically, given the UCAST field name and a value.
+    /// </summary>
+    /// <remarks>
+    /// Uses reflection, so it may be very slow.
+    /// </remarks>
+    public void SetPropertyByName(string name, ref T source, object? value)
+    {
+        if (source is not null && nameMappings.TryGetValue(name, out var accessor))
+        {
+            var prop = source.GetType().GetProperty(accessor);
+            prop?.SetValue(source, value);
+        }
+    }
+
+    // Allows direct indexing during filtering, as if this class were a dictionary.
+    public Func<ParameterExpression, Expression> this[string name]
+    {
+        get
+        {
+            return linqMappingsCache[name];
+        }
+    }
+
+}
+
+// Adds extensions to the name mapping logic, specific to Entity Framework Core model classes.
+public class EFCoreMappingConfiguration<T> : MappingConfiguration<T>
+{
+    /// <summary>
+    ///   <para>
+    ///   Constructs an EFCoreMappingConfiguration object that maps UCAST
+    ///   property names to lambda functions.<br />
+    ///   The lambda functions allow late-binding a LINQ data source into LINQ
+    ///   Property expression lookups, which are used extensively when building
+    ///   conditions over EF Core models.
+    ///   </para>
+    ///   <para>
+    ///   When deciding on names for data source properties, we follow a small set
+    ///   of default construction rules:
+    ///   <list type="bullet">
+    ///    <item>Example.Id -> "example.id"</item>
+    ///    <item>Example.LastUpdated -> "example.last_updated"</item>
+    ///    <item>Example.UserNavigation.Id -> "example.user.id"</item>
+    ///   </list>
+    ///   </para>
+    /// </summary>
+    /// <param name="namesToProperties">A dictionary, mapping UCAST field names to property lookups in the object.</param>
+    /// <param name="prefix">Name of the LINQ data source, as it will appear in UCAST field references. Used as a prefix for the generated property mappings.</param>
+    public EFCoreMappingConfiguration(Dictionary<string, string> namesToProperties, string? prefix = null) : base(namesToProperties)
+    {
+        var properties = typeof(T).GetProperties();
+        foreach (var property in properties)
+        {
+            var propertyName = property.Name;
+            // Normal properties, or a property just named "navigation" (case invariant) should be processed normally.
+            if (!propertyName.EndsWith("Navigation") || propertyName.ToLower() == "Navigation")
+            {
+                propertyName = string.IsNullOrEmpty(prefix) ? propertyName.ToSnakeCase() : $"{prefix}.{propertyName.ToSnakeCase()}";
+                nameMappings[propertyName] = property.Name;
+                linqMappingsCache[propertyName] = param => Expression.Property(param, property.Name);
+                continue;
+            }
+            // Implicit else: Properties with the "Navigation" suffix are
+            // usually ORM tooling for foreign key/entity lookups in EF Core. We
+            // indirect one level, and enumerate the non-Navigation properties
+            // of that type.
+            propertyName = property.Name[..^"Navigation".Length];
+            propertyName = string.IsNullOrEmpty(prefix) ? propertyName.ToSnakeCase() : $"{prefix}.{propertyName.ToSnakeCase()}";
+
+            Type memberType = property.PropertyType;
+            var memberProperties = memberType.GetProperties();
+            foreach (var memberProp in memberProperties)
+            {
+                // Skip cases like "Ticket.CustomerNavigation.TenantNavigation".
+                if (memberProp.Name.EndsWith("Navigation") && !memberProp.Name.Equals("Navigation", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    continue;
+                }
+                var memberPropertyName = memberProp.Name.ToSnakeCase();
+                linqMappingsCache[$"{propertyName}.{memberPropertyName}"] = param => Expression.Property(Expression.Property(param, property.Name), memberPropertyName);
+            }
+        }
+        if (namesToProperties is not null)
+        {
+            foreach (var mapping in namesToProperties)
+            {
+                // Split string on '.' characters, and build out the Expression.Property() chain accordingly.
+                var parts = mapping.Value.Split('.');
+                var startIdx = parts[0] == prefix ? 0 : 1;
+                linqMappingsCache[mapping.Key] = param => Expression.Property(param, parts[startIdx]);
+                for (var i = startIdx + 1; i < parts.Length; i++)
+                {
+                    var part = parts[i];
+                    linqMappingsCache[mapping.Key] = param => Expression.Property(linqMappingsCache[mapping.Key](param), part);
+                }
+            }
+        }
+    }
+}
+

--- a/src/Styra.Ucast.Linq/MappingConfiguration.cs
+++ b/src/Styra.Ucast.Linq/MappingConfiguration.cs
@@ -7,7 +7,8 @@ namespace Styra.Ucast.Linq;
 public class NameToLINQExpressionConfiguration : Dictionary<string, Func<ParameterExpression, Expression>>;
 
 /// <summary>
-/// This type helps wrap up the complexities of building LINQ expressions filtering, and for generating dynamic property lookups.
+/// This type helps wrap up the complexities of building LINQ expressions
+/// filtering, and for generating dynamic property lookups.
 /// </summary>
 /// <typeparam name="T">The type to build a name mapping config over.</typeparam>
 public class MappingConfiguration<T>
@@ -75,6 +76,19 @@ public class MappingConfiguration<T>
     }
 
     /// <summary>
+    /// Indexer method providing direct access, as if this class were a dictionary.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public Func<ParameterExpression, Expression> this[string name]
+    {
+        get
+        {
+            return linqMappingsCache[name];
+        }
+    }
+
+    /// <summary>
     /// Retrieves an object property dynamically, given the UCAST field name.
     /// </summary>
     /// <returns>
@@ -106,19 +120,11 @@ public class MappingConfiguration<T>
             prop?.SetValue(source, value);
         }
     }
-
-    // Allows direct indexing during filtering, as if this class were a dictionary.
-    public Func<ParameterExpression, Expression> this[string name]
-    {
-        get
-        {
-            return linqMappingsCache[name];
-        }
-    }
-
 }
-
-// Adds extensions to the name mapping logic, specific to Entity Framework Core model classes.
+/// <summary>
+/// Adds extensions to the name mapping logic, specific to Entity Framework Core model classes.
+/// </summary>
+/// <typeparam name="T">The type to build a name mapping config over.</typeparam>
 public class EFCoreMappingConfiguration<T> : MappingConfiguration<T>
 {
     /// <summary>

--- a/src/Styra.Ucast.Linq/MaskingTypes.cs
+++ b/src/Styra.Ucast.Linq/MaskingTypes.cs
@@ -1,0 +1,33 @@
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Styra.Ucast.Linq;
+
+public struct MaskResult
+{
+    [JsonProperty("masks")]
+    public Dictionary<string, MaskingFunc>? Masks;
+
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}
+
+public struct MaskingFunc
+{
+    [JsonProperty("replace", NullValueHandling = NullValueHandling.Ignore)]
+    public ReplaceFunc? Replace;
+
+    public struct ReplaceFunc
+    {
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
+        public object? Value;
+    }
+
+    public override readonly string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}

--- a/src/Styra.Ucast.Linq/MaskingTypes.cs
+++ b/src/Styra.Ucast.Linq/MaskingTypes.cs
@@ -4,6 +4,9 @@ using Newtonsoft.Json;
 
 namespace Styra.Ucast.Linq;
 
+/// <summary>
+/// The JSON wrapper object for column masking responses.
+/// </summary>
 public struct MaskResult
 {
     [JsonProperty("masks")]
@@ -15,6 +18,10 @@ public struct MaskResult
     }
 }
 
+/// <summary>
+/// JSON object describing which column masking function to use, along with any
+/// relevant parameter values for it to use.
+/// </summary>
 public struct MaskingFunc
 {
     [JsonProperty("replace", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/Styra.Ucast.Linq/StringExtensions.cs
+++ b/src/Styra.Ucast.Linq/StringExtensions.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+
+namespace Styra.Ucast.Linq;
+
+public static class StringExtensions
+{
+    public static string ToSnakeCase(this string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        return string.Concat(input.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
+    }
+}

--- a/src/Styra.Ucast.Linq/Styra.Ucast.Linq.csproj
+++ b/src/Styra.Ucast.Linq/Styra.Ucast.Linq.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>Styra.Ucast.Linq</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Styra</Authors>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/test/Styra.Ucast.Linq.Tests/UnitTest.cs
+++ b/test/Styra.Ucast.Linq.Tests/UnitTest.cs
@@ -1,6 +1,4 @@
 // This file contains basic unit tests for the library.
-using System.Linq.Expressions;
-
 namespace Styra.Ucast.Linq.Tests;
 
 // Field operations, across all JSON primitive types (null, bool, int, double, string), with expected results from equivalent LINQ queries.
@@ -185,26 +183,26 @@ public class UnitTestCompoundExprs
     public static IEnumerable<object[]> AndTestData()
     {
         yield return new object[] { new UCASTNode { Type = "compound", Op = "and", Value = new List<UCASTNode>{
-            new UCASTNode { Type = "field", Op = "eq", Field = "data.name", Value = "Lake Beta" },
-            new UCASTNode { Type = "field", Op = "eq", Field = "data.flood_stage", Value = true },
+            new() { Type = "field", Op = "eq", Field = "data.name", Value = "Lake Beta" },
+            new() { Type = "field", Op = "eq", Field = "data.flood_stage", Value = true },
         } }, testdata.Where(d => d.Name == "Lake Beta" && d.FloodStage).ToList() };
     }
 
     public static IEnumerable<object[]> OrTestData()
     {
         yield return new object[] { new UCASTNode { Type = "compound", Op = "or", Value = new List<UCASTNode>{
-            new UCASTNode { Type = "field", Op = "eq", Field = "data.name", Value = "Lake Beta" },
-            new UCASTNode { Type = "field", Op = "eq", Field = "data.flood_stage", Value = false },
+            new() { Type = "field", Op = "eq", Field = "data.name", Value = "Lake Beta" },
+            new() { Type = "field", Op = "eq", Field = "data.flood_stage", Value = false },
         } }, testdata.Where(d => d.Name == "Lake Beta" || !d.FloodStage).ToList() };
     }
 
     public static IEnumerable<object[]> AndNestedTestData()
     {
         yield return new object[] { new UCASTNode { Type = "compound", Op = "and", Value = new List<UCASTNode>{
-            new UCASTNode { Type = "field", Op = "eq", Field = "data.id", Value = 2 },
-            new UCASTNode { Type = "compound", Op = "or", Value = new List<UCASTNode>{
-                new UCASTNode { Type = "field", Op = "ge", Field = "data.water_level_meters", Value = 2.5 },
-                new UCASTNode { Type = "field", Op = "eq", Field = "data.flood_stage", Value = false },
+            new() { Type = "field", Op = "eq", Field = "data.id", Value = 2 },
+            new() { Type = "compound", Op = "or", Value = new List<UCASTNode>{
+                new() { Type = "field", Op = "ge", Field = "data.water_level_meters", Value = 2.5 },
+                new() { Type = "field", Op = "eq", Field = "data.flood_stage", Value = false },
             } },
 
         } }, testdata.Where(d => d.Id == 2 && (d.WaterLevelMeters >= 2.5 || !d.FloodStage)).ToList() };
@@ -213,10 +211,10 @@ public class UnitTestCompoundExprs
     public static IEnumerable<object[]> OrNestedTestData()
     {
         yield return new object[] { new UCASTNode { Type = "compound", Op = "or", Value = new List<UCASTNode>{
-            new UCASTNode { Type = "field", Op = "eq", Field = "data.id", Value = 2 },
-            new UCASTNode { Type = "compound", Op = "and", Value = new List<UCASTNode>{
-                new UCASTNode { Type = "field", Op = "ge", Field = "data.water_level_meters", Value = 2.5 },
-                new UCASTNode { Type = "field", Op = "eq", Field = "data.flood_stage", Value = false },
+            new() { Type = "field", Op = "eq", Field = "data.id", Value = 2 },
+            new() { Type = "compound", Op = "and", Value = new List<UCASTNode>{
+                new() { Type = "field", Op = "ge", Field = "data.water_level_meters", Value = 2.5 },
+                new() { Type = "field", Op = "eq", Field = "data.flood_stage", Value = false },
             } },
 
         } }, testdata.Where(d => d.Id == 2 || (d.WaterLevelMeters >= 2.5 && !d.FloodStage)).ToList() };
@@ -231,24 +229,24 @@ public class UnitTestREADMEExample
     public void TestREADMEExample()
     {
         int[] numbers = { -1523, 1894, -456, 789, -1002, 345, -1789, 567, 1234, -890, 123, -1456, 1678, -234, 567, -1890, 901, -345, 1567, -789 };
-        List<SimpleRecord> collection = numbers.Select(n => new SimpleRecord(n)).ToList();
+        List<SimpleRecord> collection = [.. numbers.Select(n => new SimpleRecord(n))];
         var expected = collection.Where(x => x.Value >= 1500 || (x.Value < 400 && (x.Value > 0 || x.Value < -1500))).OrderBy(x => x.Value).ToList();
         var conditions = new UCASTNode
         {
             Type = "compound",
             Op = "or",
             Value = new List<UCASTNode>{
-            new UCASTNode { Type = "field", Op = "ge", Field = "r.value", Value = 1500 },
-            new UCASTNode { Type = "compound", Op = "and", Value = new List<UCASTNode>{
-                new UCASTNode { Type = "field", Op = "lt", Field = "r.value", Value = 400 },
-                new UCASTNode { Type = "compound", Op = "or", Value = new List<UCASTNode>{
-                    new UCASTNode { Type = "field", Op = "gt", Field = "r.value", Value = 0 },
-                    new UCASTNode { Type = "field", Op = "lt", Field = "r.value", Value = -1500 },
+            new() { Type = "field", Op = "ge", Field = "r.value", Value = 1500 },
+            new() { Type = "compound", Op = "and", Value = new List<UCASTNode>{
+                new() { Type = "field", Op = "lt", Field = "r.value", Value = 400 },
+                new() { Type = "compound", Op = "or", Value = new List<UCASTNode>{
+                    new() { Type = "field", Op = "gt", Field = "r.value", Value = 0 },
+                    new() { Type = "field", Op = "lt", Field = "r.value", Value = -1500 },
                 } },
             } },
         }
         };
-        var result = collection.AsQueryable().ApplyUCASTFilter(conditions, QueryableExtensions.BuildDefaultMapperDictionary<SimpleRecord>("r")).OrderBy(x => x.Value).ToList();
+        var result = collection.AsQueryable().ApplyUCASTFilter(conditions, new MappingConfiguration<SimpleRecord>(prefix: "r")).OrderBy(x => x.Value).ToList();
         Assert.Equivalent(expected, result, true);
     }
 }
@@ -256,7 +254,8 @@ public class UnitTestREADMEExample
 // AI-generated, used to provide a dataset for LINQ queries.
 public class UnitTestDataSource
 {
-    public static Dictionary<string, Func<ParameterExpression, Expression>> HydrologyDataMapping = QueryableExtensions.BuildDefaultMapperDictionary<HydrologyData>("data");
+    public static readonly MappingConfiguration<HydrologyData> HydrologyDataMapping = new(prefix: "data");
+
     public class HydrologyData
     {
         public int Id { get; set; }

--- a/test/Styra.Ucast.Linq.Tests/UnitTest.cs
+++ b/test/Styra.Ucast.Linq.Tests/UnitTest.cs
@@ -4,7 +4,7 @@ namespace Styra.Ucast.Linq.Tests;
 // Field operations, across all JSON primitive types (null, bool, int, double, string), with expected results from equivalent LINQ queries.
 public class UnitTestFieldExprs
 {
-    public static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
 
     [Theory]
     [MemberData(nameof(EqTestData))]
@@ -146,7 +146,7 @@ public class UnitTestFieldExprs
 // Compound operations, with expected results from equivalent LINQ queries.
 public class UnitTestCompoundExprs
 {
-    public static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
 
     [Theory]
     [MemberData(nameof(AndTestData))]
@@ -248,6 +248,23 @@ public class UnitTestREADMEExample
         };
         var result = collection.AsQueryable().ApplyUCASTFilter(conditions, new MappingConfiguration<SimpleRecord>(prefix: "r")).OrderBy(x => x.Value).ToList();
         Assert.Equivalent(expected, result, true);
+    }
+}
+
+public class UnitTestMasking
+{
+    private static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+
+    [Fact]
+    public void TestMaskingReplace()
+    {
+        Dictionary<string, MaskingFunc> maskingRules = new()
+        {
+            { "data.name", new MaskingFunc() { Replace = new() { Value = "***" } } },
+        };
+
+        var maskedList = testdata.MaskElements(maskingRules, UnitTestDataSource.HydrologyDataMapping);
+        Assert.All(maskedList, item => Assert.Equal("***", item.Name));
     }
 }
 


### PR DESCRIPTION
## What changed?

 - Data masking support (just `replace`, currently!)
 - Rework of how LINQ name mappings are handled.
 - Numerous small refactors.

## Remaining work

 - [x] Masking unit tests

## Resources

 - See https://github.com/StyraInc/styra-demo-tickethub/pull/570 for the intended downstream masking usecase.