### PR TITLE
MappingConfiguration: Fix arbitrary and nested mappings + Fix EF Core mappings

### DIFF
--- a/src/Styra.Ucast.Linq/MappingConfiguration.cs
+++ b/src/Styra.Ucast.Linq/MappingConfiguration.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Security.Cryptography;
+using Microsoft.VisualBasic;
 
 namespace Styra.Ucast.Linq;
 
@@ -14,6 +18,7 @@ public class NameToLINQExpressionConfiguration : Dictionary<string, Func<Paramet
 public class MappingConfiguration<T>
 {
     // Cache of generated mappings, so we don't have to reconstruct them every time.
+    protected Dictionary<string, string> baseNameMappings = GetUCASTToPropertyNamesMapping();
     protected Dictionary<string, string> nameMappings = new(typeof(T).GetProperties().Length);
     protected Dictionary<string, Func<ParameterExpression, Expression>> linqMappingsCache = new(typeof(T).GetProperties().Length);
     protected string namePrefix = typeof(T).Name.ToLower();
@@ -40,28 +45,38 @@ public class MappingConfiguration<T>
     public MappingConfiguration(Dictionary<string, string>? namesToProperties = null, string? prefix = null)
     {
         namePrefix = prefix ?? namePrefix;
-        foreach (var property in typeof(T).GetProperties())
+        foreach (var kv in baseNameMappings)
         {
-            var snakeCasedProperty = property.Name.ToSnakeCase();
-            snakeCasedProperty = string.IsNullOrEmpty(namePrefix) ? snakeCasedProperty : $"{namePrefix}.{snakeCasedProperty}";
-            nameMappings[snakeCasedProperty] = property.Name;
-            linqMappingsCache[snakeCasedProperty] = param => Expression.Property(param, property.Name);
+            var key = $"{namePrefix}.{kv.Key}";
+            nameMappings[key] = kv.Value;
+            linqMappingsCache[key] = param => Expression.Property(param, kv.Value);
         }
         if (namesToProperties is not null)
         {
             foreach (var mapping in namesToProperties)
             {
+                nameMappings[mapping.Key] = nameMappings[mapping.Value];
                 // Split string on '.' characters, and build out the Expression.Property() chain accordingly.
                 var parts = mapping.Value.Split('.');
-                var startIdx = parts[0] == prefix ? 0 : 1;
-                linqMappingsCache[mapping.Key] = param => Expression.Property(param, parts[startIdx]);
-                for (var i = startIdx + 1; i < parts.Length; i++)
-                {
-                    var part = parts[i];
-                    linqMappingsCache[mapping.Key] = param => Expression.Property(linqMappingsCache[mapping.Key](param), part);
-                }
+
+                // Build up the linq expression by wrapping each successive member access.
+                // Example params when evaluated for "ticket.customer.id": (ParameterExpression, {"ticket"}, {"customer", "id"})
+                linqMappingsCache[mapping.Key] = param => NestedPropertyAccessFromParts(param, parts[..1], parts[1..]);
             }
         }
+    }
+
+    // baseExpr will be a ParameterExpression normally at the top-level.
+    public Expression NestedPropertyAccessFromParts(Expression baseExpr, string[] seen, string[] remaining)
+    {
+        // Base case, no indexing left to do!
+        if (remaining.Length == 0)
+        {
+            return baseExpr;
+        }
+        // Recursive case: Pull off a property, and dive down to the next level.
+        var indexer = nameMappings[string.Join(".", [.. seen, remaining[0]])].Split(".").Last();
+        return NestedPropertyAccessFromParts(Expression.Property(baseExpr, indexer), [.. seen, remaining[0]], remaining[1..]);
     }
 
     /// <summary>
@@ -73,6 +88,15 @@ public class MappingConfiguration<T>
     public Dictionary<string, Func<ParameterExpression, Expression>> GetLinqMappings()
     {
         return new(linqMappingsCache);
+    }
+
+    /// <summary>
+    /// Returns the stored UCAST field name to property name mappings.
+    /// </summary>
+    /// <returns></returns>
+    public Dictionary<string, string> GetNameMappings()
+    {
+        return new(nameMappings);
     }
 
     /// <summary>
@@ -112,9 +136,27 @@ public class MappingConfiguration<T>
     {
         if (source is not null && nameMappings.TryGetValue(name, out var accessor))
         {
-            return source.GetType().GetProperty(accessor)?.GetValue(source);
+            return GetPropertyValue(source, accessor);
         }
         return null;
+    }
+
+    private static object? GetPropertyValue(object? src, string? propName)
+    {
+        if (src == null) return null;
+        if (propName == null) return null;
+
+        if (propName.Contains('.')) //complex type, nested
+        {
+            var temp = propName.Split(['.'], 2);
+            var outer = GetPropertyValue(src, temp[0]);
+            return GetPropertyValue(outer, temp[1]);
+        }
+        else
+        {
+            var prop = src.GetType().GetProperty(propName);
+            return prop?.GetValue(src, null);
+        }
     }
 
     /// <summary>
@@ -131,6 +173,64 @@ public class MappingConfiguration<T>
             prop?.SetValue(source, value);
         }
     }
+
+    protected static bool IsClassOrStruct(Type type)
+    {
+        return type.IsClass || (type.IsValueType && !type.IsPrimitive && !type.IsEnum);
+    }
+
+    private static bool IsReadableMember(MemberInfo member)
+    {
+        if (member is FieldInfo)
+            return true;
+        if (member is PropertyInfo property)
+            return property.CanRead;
+        return false;
+    }
+
+    /// <summary>
+    /// Generates a "raw" UCAST -> property names mapping for the type.
+    /// Expands down one level, to pick up properties of struct member fields.
+    /// </summary>
+    /// <returns>The dictionary mapping UCAST field names to property names of the object.</returns>
+    private static Dictionary<string, string> GetUCASTToPropertyNamesMapping()
+    {
+        var properties = typeof(T).GetProperties(BindingFlags.DeclaredOnly |
+            BindingFlags.Public | BindingFlags.Instance);
+        Dictionary<string, string> result = new(properties.Length);
+
+        foreach (var property in properties)
+        {
+            var snakeCasedProperty = property.Name.ToSnakeCase();
+            result[snakeCasedProperty] = property.Name;
+            Type propType = property.PropertyType;
+            if (IsClassOrStruct(propType))
+            {
+                var memberPropertyMapping = GetUCASTToPropertyNamesMapping(propType);
+                foreach (var kv in memberPropertyMapping)
+                {
+                    result[snakeCasedProperty + "." + kv.Key] = property.Name + "." + kv.Value;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, string> GetUCASTToPropertyNamesMapping(Type type)
+    {
+        var properties = type.GetProperties(BindingFlags.DeclaredOnly |
+            BindingFlags.Public | BindingFlags.Instance);
+        Dictionary<string, string> result = new(properties.Length);
+
+        foreach (var property in properties)
+        {
+            var snakeCasedProperty = property.Name.ToSnakeCase();
+            result[snakeCasedProperty] = property.Name;
+        }
+
+        return result;
+    }
 }
 /// <summary>
 /// Adds extensions to the name mapping logic, specific to Entity Framework Core model classes.
@@ -138,6 +238,8 @@ public class MappingConfiguration<T>
 /// <typeparam name="T">The type to build a name mapping config over.</typeparam>
 public class EFCoreMappingConfiguration<T> : MappingConfiguration<T>
 {
+    protected new Dictionary<string, string> baseNameMappings = GetUCASTToPropertyNamesMapping();
+
     /// <summary>
     ///   <para>
     ///   Constructs an EFCoreMappingConfiguration object that maps UCAST
@@ -160,24 +262,64 @@ public class EFCoreMappingConfiguration<T> : MappingConfiguration<T>
     /// <param name="prefix">Name of the LINQ data source, as it will appear in UCAST field references. Used as a prefix for the generated property mappings.</param>
     public EFCoreMappingConfiguration(Dictionary<string, string>? namesToProperties = null, string? prefix = null) : base(namesToProperties, prefix)
     {
+        foreach (var kv in baseNameMappings)
+        {
+            var key = $"{namePrefix}.{kv.Key}";
+            nameMappings[key] = kv.Value;
+            var parts = kv.Value.Split('.');
+            // Build up the linq expression by wrapping each successive member access.
+            linqMappingsCache[key] = param => Expression.Property(param, parts[0]);
+            for (var i = 1; i < parts.Length; i++)
+            {
+                var part = parts[i];
+                linqMappingsCache[key] = param => Expression.Property(linqMappingsCache[key](param), part);
+            }
+        }
+        if (namesToProperties is not null)
+        {
+            foreach (var mapping in namesToProperties)
+            {
+                // Split string on '.' characters, and build out the Expression.Property() chain accordingly.
+                var parts = mapping.Value.Split('.');
+                var startIdx = parts[0] == namePrefix ? 1 : 0;
+                nameMappings[mapping.Key] = nameMappings[mapping.Value];
+                // Build up the linq expression by wrapping each successive member access.
+                linqMappingsCache[mapping.Key] = param => Expression.Property(param, parts[startIdx]);
+                for (var i = startIdx + 1; i < parts.Length; i++)
+                {
+                    var part = parts[i];
+                    linqMappingsCache[mapping.Key] = param => Expression.Property(linqMappingsCache[mapping.Key](param), part);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generates a "raw" UCAST -> property names mapping for the type.
+    /// This version is updated to handle Navigation types that are common with EF Core.
+    /// </summary>
+    /// <returns>The dictionary mapping UCAST field names to property names of the object.</returns>
+    private static Dictionary<string, string> GetUCASTToPropertyNamesMapping()
+    {
         var properties = typeof(T).GetProperties();
+        Dictionary<string, string> result = new(properties.Length);
+
         foreach (var property in properties)
         {
             var propertyName = property.Name;
             // Normal properties, or a property just named "navigation" (case invariant) should be processed normally.
-            if (!propertyName.EndsWith("Navigation") || propertyName.ToLower() == "Navigation")
+            if (!property.Name.EndsWith("Navigation") || propertyName.Equals("Navigation", StringComparison.CurrentCultureIgnoreCase))
             {
-                propertyName = string.IsNullOrEmpty(prefix) ? propertyName.ToSnakeCase() : $"{prefix}.{propertyName.ToSnakeCase()}";
-                nameMappings[propertyName] = property.Name;
-                linqMappingsCache[propertyName] = param => Expression.Property(param, property.Name);
+                var snakeCasedProperty = property.Name.ToSnakeCase();
+                result[snakeCasedProperty] = property.Name;
                 continue;
             }
+
             // Implicit else: Properties with the "Navigation" suffix are
             // usually ORM tooling for foreign key/entity lookups in EF Core. We
             // indirect one level, and enumerate the non-Navigation properties
             // of that type.
             propertyName = property.Name[..^"Navigation".Length];
-            propertyName = string.IsNullOrEmpty(prefix) ? propertyName.ToSnakeCase() : $"{prefix}.{propertyName.ToSnakeCase()}";
 
             Type memberType = property.PropertyType;
             var memberProperties = memberType.GetProperties();
@@ -189,24 +331,11 @@ public class EFCoreMappingConfiguration<T> : MappingConfiguration<T>
                     continue;
                 }
                 var memberPropertyName = memberProp.Name.ToSnakeCase();
-                linqMappingsCache[$"{propertyName}.{memberPropertyName}"] = param => Expression.Property(Expression.Property(param, property.Name), memberPropertyName);
+                result[memberPropertyName] = $"{property.Name}.{memberProp.Name}";
             }
         }
-        if (namesToProperties is not null)
-        {
-            foreach (var mapping in namesToProperties)
-            {
-                // Split string on '.' characters, and build out the Expression.Property() chain accordingly.
-                var parts = mapping.Value.Split('.');
-                var startIdx = parts[0] == prefix ? 0 : 1;
-                linqMappingsCache[mapping.Key] = param => Expression.Property(param, parts[startIdx]);
-                for (var i = startIdx + 1; i < parts.Length; i++)
-                {
-                    var part = parts[i];
-                    linqMappingsCache[mapping.Key] = param => Expression.Property(linqMappingsCache[mapping.Key](param), part);
-                }
-            }
-        }
+
+        return result;
     }
 }
 

--- a/src/Styra.Ucast.Linq/MappingConfiguration.cs
+++ b/src/Styra.Ucast.Linq/MappingConfiguration.cs
@@ -78,7 +78,7 @@ public class MappingConfiguration<T>
     /// <summary>
     /// Indexer method providing direct access, as if this class were a dictionary.
     /// </summary>
-    /// <param name="name"></param>
+    /// <param name="name">The UCAST field name to look up.</param>
     /// <returns></returns>
     public Func<ParameterExpression, Expression> this[string name]
     {
@@ -86,6 +86,17 @@ public class MappingConfiguration<T>
         {
             return linqMappingsCache[name];
         }
+    }
+
+    /// <summary>
+    /// Removes a mapping, given the UCAST field name.
+    /// </summary>
+    /// <param name="name">The UCAST field name to attempt to remove.</param>
+    /// <returns></returns>
+    public bool Remove(string name)
+    {
+        nameMappings.Remove(name);
+        return linqMappingsCache.Remove(name);
     }
 
     /// <summary>
@@ -147,7 +158,7 @@ public class EFCoreMappingConfiguration<T> : MappingConfiguration<T>
     /// </summary>
     /// <param name="namesToProperties">A dictionary, mapping UCAST field names to property lookups in the object.</param>
     /// <param name="prefix">Name of the LINQ data source, as it will appear in UCAST field references. Used as a prefix for the generated property mappings.</param>
-    public EFCoreMappingConfiguration(Dictionary<string, string> namesToProperties, string? prefix = null) : base(namesToProperties)
+    public EFCoreMappingConfiguration(Dictionary<string, string>? namesToProperties = null, string? prefix = null) : base(namesToProperties, prefix)
     {
         var properties = typeof(T).GetProperties();
         foreach (var property in properties)

--- a/test/Styra.Ucast.Linq.Tests/UnitTest.cs
+++ b/test/Styra.Ucast.Linq.Tests/UnitTest.cs
@@ -176,6 +176,33 @@ public class UnitTestFieldExprsWithCustomNameBinding
         Assert.Equivalent(result, expected);
     }
 
+    [Theory]
+    [MemberData(nameof(NinTestData))]
+    public void TestNinWithCustomEFCoreMapping(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
+    {
+        EFCoreMappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(new Dictionary<string, string> {
+            {"hydro.id", "data.id"},
+            {"hydro.name", "data.name"},
+            {"hydro.flood_stage", "data.flood_stage"},
+            {"hydro.water_level_meters", "data.water_level_meters"},
+        }, "data");
+        var result = hydrologyTestData.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
+        Assert.Equivalent(result, expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(NestedNinTestData))]
+    public void TestNestedNinWithCustomEFCoreMapping(UCASTNode node, List<UnitTestDataSource.Ticket> expected)
+    {
+        EFCoreMappingConfiguration<UnitTestDataSource.Ticket> mapping = new(new Dictionary<string, string> {
+            {"t.id", "ticket.id"},
+            {"c.id", "ticket.customer.id"},
+            {"c.name", "ticket.customer.name"},
+        }, "ticket");
+        var result = ticketTestData.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
+        Assert.Equivalent(result, expected);
+    }
+
     public static IEnumerable<object[]> NinTestData()
     {
         {
@@ -405,6 +432,7 @@ public class UnitTestDataSource
         public string? Description { get; set; }
         public required Customer Customer { get; set; }
         public bool Resolved { get; set; }
+        public User? UserNavigation { get; set; }
     }
 
     public class Customer
@@ -414,6 +442,12 @@ public class UnitTestDataSource
         public DateTime? LastUpdated { get; set; }
     }
 
+    public class User
+    {
+        public int Id { get; set; }
+        public required string Name { get; set; }
+    }
+
     public static List<Ticket> GetTickets()
     {
         return [
@@ -421,7 +455,7 @@ public class UnitTestDataSource
             new Ticket { Id = 2, Description = "Flooding in basement", Customer = new Customer { Id = 2, Name = "Jane Smith" }, Resolved = true },
             new Ticket { Id = 3, Description = "Water level sensor malfunction", Customer = new Customer { Id = 3, Name = "Alice Johnson" }, Resolved = false },
             new Ticket { Id = 4, Description = "Leak in the main pipe", Customer = new Customer { Id = 4, Name = "Bob Brown" }, Resolved = true },
-            new Ticket { Id = 5, Description = null, Customer = new Customer { Id = 5, Name = "Charlie Davis" }, Resolved = false }
+            new Ticket { Id = 5, Description = null, Customer = new Customer { Id = 5, Name = "Charlie Davis" }, UserNavigation = new User { Id = 5, Name = "Eratosthenes" }, Resolved = false }
         ];
     }
 }

--- a/test/Styra.Ucast.Linq.Tests/UnitTest.cs
+++ b/test/Styra.Ucast.Linq.Tests/UnitTest.cs
@@ -5,12 +5,13 @@ namespace Styra.Ucast.Linq.Tests;
 public class UnitTestFieldExprs
 {
     private static readonly List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(prefix: "data");
 
     [Theory]
     [MemberData(nameof(EqTestData))]
     public void TestEq(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -18,7 +19,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(NeTestData))]
     public void TestNe(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -26,7 +27,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(GtTestData))]
     public void TestGt(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -34,7 +35,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(GeTestData))]
     public void TestGe(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -42,7 +43,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(LtTestData))]
     public void TestLt(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -50,7 +51,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(LeTestData))]
     public void TestLe(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -58,7 +59,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(InTestData))]
     public void TestIn(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -66,7 +67,7 @@ public class UnitTestFieldExprs
     [MemberData(nameof(NinTestData))]
     public void TestNin(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(result, expected);
     }
 
@@ -147,12 +148,13 @@ public class UnitTestFieldExprs
 public class UnitTestCompoundExprs
 {
     private static readonly List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(prefix: "data");
 
     [Theory]
     [MemberData(nameof(AndTestData))]
     public void TestAnd(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -160,7 +162,7 @@ public class UnitTestCompoundExprs
     [MemberData(nameof(OrTestData))]
     public void TestOr(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -168,7 +170,7 @@ public class UnitTestCompoundExprs
     [MemberData(nameof(AndNestedTestData))]
     public void TestAndNested(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -176,7 +178,7 @@ public class UnitTestCompoundExprs
     [MemberData(nameof(OrNestedTestData))]
     public void TestOrNested(UCASTNode node, List<UnitTestDataSource.HydrologyData> expected)
     {
-        var result = testdata.AsQueryable().ApplyUCASTFilter(node, UnitTestDataSource.HydrologyDataMapping).ToList();
+        var result = testdata.AsQueryable().ApplyUCASTFilter(node, mapping).ToList();
         Assert.Equivalent(expected, result, true);
     }
 
@@ -254,6 +256,7 @@ public class UnitTestREADMEExample
 public class UnitTestMasking
 {
     private static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(prefix: "data");
 
     [Fact]
     public void TestMaskingReplace()
@@ -263,7 +266,55 @@ public class UnitTestMasking
             { "data.name", new MaskingFunc() { Replace = new() { Value = "***" } } },
         };
 
-        var maskedList = testdata.MaskElements(maskingRules, UnitTestDataSource.HydrologyDataMapping);
+        var maskedList = testdata.MaskElements(maskingRules, mapping);
+        Assert.All(maskedList, item => Assert.Equal("***", item.Name));
+    }
+
+    [Fact]
+    public void TestMaskingReplaceWithNamesToProperties()
+    {
+        Dictionary<string, MaskingFunc> maskingRules = new()
+        {
+            { "hydro.name", new MaskingFunc() { Replace = new() { Value = "***" } } },
+        };
+
+        MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(new Dictionary<string, string> {
+            {"hydro.name", "data.name"},
+        }, "data");
+        var maskedList = testdata.MaskElements(maskingRules, mapping);
+        Assert.All(maskedList, item => Assert.Equal("***", item.Name));
+    }
+}
+
+public class UnitTestMaskingEFCore
+{
+    private static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly EFCoreMappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(prefix: "data");
+
+    [Fact]
+    public void TestMaskingReplace()
+    {
+        Dictionary<string, MaskingFunc> maskingRules = new()
+        {
+            { "data.name", new MaskingFunc() { Replace = new() { Value = "***" } } },
+        };
+
+        var maskedList = testdata.MaskElements(maskingRules, mapping);
+        Assert.All(maskedList, item => Assert.Equal("***", item.Name));
+    }
+
+    [Fact]
+    public void TestMaskingReplaceWithNamesToProperties()
+    {
+        Dictionary<string, MaskingFunc> maskingRules = new()
+        {
+            { "hydro.name", new MaskingFunc() { Replace = new() { Value = "***" } } },
+        };
+
+        EFCoreMappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(new Dictionary<string, string> {
+            {"hydro.name", "data.name"},
+        }, "data");
+        var maskedList = testdata.MaskElements(maskingRules, mapping);
         Assert.All(maskedList, item => Assert.Equal("***", item.Name));
     }
 }
@@ -271,8 +322,6 @@ public class UnitTestMasking
 // AI-generated, used to provide a dataset for LINQ queries.
 public class UnitTestDataSource
 {
-    public static readonly MappingConfiguration<HydrologyData> HydrologyDataMapping = new(prefix: "data");
-
     public class HydrologyData
     {
         public int Id { get; set; }


### PR DESCRIPTION
## What changed?

In an upstream project, we ran into issues around arbitrary name mappings (e.g. `users.name => ticket.user.name`) not working. This led to a bug hunt and extensive refactoring. There are now far more extensive unit tests covering these code paths.

Summary:
 - Much more thorough unit test coverage.
   - Testing arbitrary name mappings (name that have no analogue in the source object)
   - Testing nested mappings (allowing conditions over struct members, like `ticket.customer.name`).
 - Complete rework of LINQ `Expression.Property` chain construction.
 - More robust handling of nested property lookups in general.

Fixes: #22 