### PR TITLE
masking: Allow nested objects for table + column mappings.

### DIFF
--- a/src/Styra.Ucast.Linq/MaskingTypes.cs
+++ b/src/Styra.Ucast.Linq/MaskingTypes.cs
@@ -12,7 +12,7 @@ public struct MaskResult
     [JsonProperty("masks")]
     public Dictionary<string, MaskingFunc>? Masks;
 
-    public override string ToString()
+    public override readonly string ToString()
     {
         return JsonConvert.SerializeObject(this);
     }
@@ -24,8 +24,18 @@ public struct MaskResult
 /// </summary>
 public struct MaskingFunc
 {
+    // Extra machinery is required to allow for the underscore variant of the field.
+    private ReplaceFunc? _replace;
+
+    [JsonProperty("_replace", NullValueHandling = NullValueHandling.Ignore)]
+    public ReplaceFunc? ReplaceAlt { get; set; }
+
     [JsonProperty("replace", NullValueHandling = NullValueHandling.Ignore)]
-    public ReplaceFunc? Replace;
+    public ReplaceFunc? Replace
+    {
+        get { return _replace ?? ReplaceAlt; }
+        set { _replace = value; }
+    }
 
     public struct ReplaceFunc
     {

--- a/test/Styra.Ucast.Linq.Tests/UnitTest.cs
+++ b/test/Styra.Ucast.Linq.Tests/UnitTest.cs
@@ -368,6 +368,22 @@ public class UnitTestMasking
         var maskedList = testdata.MaskElements(maskingRules, mapping);
         Assert.All(maskedList, item => Assert.Equal("***", item.Name));
     }
+
+    [Fact]
+    public void TestMaskingReplaceWithNestedDictionary()
+    {
+        Dictionary<string, Dictionary<string, MaskingFunc>> maskingRules = new()
+        {
+            { "hydro", new() { { "name", new MaskingFunc() { Replace = new() { Value = "***" } } }, } },
+        };
+
+
+        MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(new Dictionary<string, string> {
+            {"hydro.name", "data.name"},
+        }, "data");
+        var maskedList = testdata.MaskElements(maskingRules, mapping);
+        Assert.All(maskedList, item => Assert.Equal("***", item.Name));
+    }
 }
 
 public class UnitTestMaskingEFCore
@@ -396,6 +412,21 @@ public class UnitTestMaskingEFCore
         };
 
         EFCoreMappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(new Dictionary<string, string> {
+            {"hydro.name", "data.name"},
+        }, "data");
+        var maskedList = testdata.MaskElements(maskingRules, mapping);
+        Assert.All(maskedList, item => Assert.Equal("***", item.Name));
+    }
+
+    [Fact]
+    public void TestMaskingReplaceWithNestedDictionary()
+    {
+        Dictionary<string, Dictionary<string, MaskingFunc>> maskingRules = new()
+        {
+            { "hydro", new() { { "name", new MaskingFunc() { Replace = new() { Value = "***" } } }, } },
+        };
+
+        MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(new Dictionary<string, string> {
             {"hydro.name", "data.name"},
         }, "data");
         var maskedList = testdata.MaskElements(maskingRules, mapping);


### PR DESCRIPTION
## What changed?

This PR allows nested objects for `table.column` mappings (e.g. `{"table": {"column": { ... }}}`, and now also supports the `_replace` alternative key for the masking function "replace", in cases where it might otherwise parse ambiguously.