### PR TITLE
src: Extend numeric type conversion system.

### DIFF
--- a/src/Styra.Ucast.Linq/QueryableExtensions.cs
+++ b/src/Styra.Ucast.Linq/QueryableExtensions.cs
@@ -7,6 +7,35 @@ namespace Styra.Ucast.Linq;
 
 public static class QueryableExtensions
 {
+    private static readonly Dictionary<Type, int> NumericTypePrecedence = new()
+    {
+        { typeof(byte), 1 },
+        { typeof(short), 2 },
+        { typeof(int), 3 },
+        { typeof(long), 4 },
+        { typeof(float), 5 },
+        { typeof(double), 6 },
+        { typeof(decimal), 7 }
+    };
+
+    public static bool IsNumericType(Type t)
+    {
+        return NumericTypePrecedence.TryGetValue(t, out int _);
+    }
+
+    public static Type GetHigherPrecedenceNumericType(Type a, Type b)
+    {
+        if (a == b) { return a; }
+
+        if (NumericTypePrecedence.TryGetValue(a, out int aPrecedence) &&
+            NumericTypePrecedence.TryGetValue(b, out int bPrecedence))
+        {
+            return aPrecedence > bPrecedence ? a : b;
+        }
+
+        throw new InvalidOperationException($"Cannot determine precedence between {a} and {b}");
+    }
+
     /// <summary>
     /// Builds a LINQ Lambda Expression from the UCAST tree, and then invokes
     /// it under a LINQ Where expression on some queryable data source.<br />
@@ -54,28 +83,52 @@ public static class QueryableExtensions
     /// the binary expressions won't fail at runtime due to type mismatches
     /// between operands.
     /// </remarks>
+    /// <typeparam name="T">The LINQ data source type.</typeparam>
     /// <param name="node">Current UCAST node in the conditions tree.</param>
-    /// <param name="parameter">LINQ data source (same type as <typeparamref name="T"/>).</param>
+    /// <param name="parameter">LINQ data source (usually same type as <typeparamref name="T"/>).</param>
     /// <param name="mapper">Dictionary mapping UCAST property names to lambdas that generate LINQ Expressions.</param>
     /// <returns>Result, a LINQ Expression (Usually a BinaryExpression).</returns>
     private static Expression BuildFieldExpression<T>(UCASTNode node, ParameterExpression parameter, MappingConfiguration<T> mapper)
     {
         var property = mapper[node.Field!](parameter); // Note: This will throw a KeyNotFoundException if the field name does not exist.
+        // We pull out the in/nin operators early, due to different args handling.
+        return node.Op.ToLower() switch
+        {
+            "in" => BuildFieldInExpression<T>(node, property, mapper),
+            "nin" => Expression.Not(BuildFieldInExpression<T>(node, property, mapper)),
+            _ => BuildFieldExpressionFromProperty<T>(node, property, mapper),
+        };
+    }
+
+    /// <summary>
+    /// The inner logic of <c>BuildFieldExpression</c>.
+    /// </summary>
+    /// <typeparam name="T">The LINQ</typeparam>
+    /// <param name="node">Current UCAST node in the conditions tree.</param>
+    /// <param name="property">Derefered property lookup expression on the LINQ data source.</param>
+    /// <param name="mapper">Dictionary mapping UCAST property names to lambdas that generate LINQ Expressions.</param>
+    /// <returns>Result, a LINQ Expression (Usually a BinaryExpression).</returns>
+    /// <exception cref="ArgumentException">Thrown when arguments are of incompatible types.</exception>
+    private static Expression BuildFieldExpressionFromProperty<T>(UCASTNode node, Expression property, MappingConfiguration<T> mapper)
+    {
         Expression value = Expression.Constant(node.Value);
 
-        // TODO: Add more robust type mismatch handling and possibly exceptions.
         Type lhsType = property.Type;
         Type rhsType = value.Type;
         if (lhsType != rhsType)
         {
-            // Upcast smaller numeric type from System.Int32 -> System.Int64.
-            if (lhsType == typeof(int) && rhsType == typeof(long))
+            if (IsNumericType(lhsType) && IsNumericType(rhsType))
             {
-                property = Expression.Convert(property, typeof(long));
-            }
-            else if (lhsType == typeof(long) && rhsType == typeof(int))
-            {
-                value = Expression.Convert(value, typeof(long));
+                var exprType = GetHigherPrecedenceNumericType(lhsType, rhsType);
+
+                if (lhsType != exprType)
+                {
+                    property = Expression.Convert(property, exprType);
+                }
+                else if (rhsType != exprType)
+                {
+                    value = Expression.Convert(value, exprType);
+                }
             }
         }
 
@@ -90,8 +143,6 @@ public static class QueryableExtensions
             "lt" => Expression.LessThan(property, value),
             "le" => Expression.LessThanOrEqual(property, value),
             "lte" => Expression.LessThanOrEqual(property, value),
-            "in" => BuildFieldInExpression<T>(node, parameter, mapper),
-            "nin" => Expression.Not(BuildFieldInExpression<T>(node, parameter, mapper)),
             _ => throw new ArgumentException($"Unknown operator: {node.Op}"),
         };
     }
@@ -101,10 +152,10 @@ public static class QueryableExtensions
     /// Builds a collection of field-level equality checks, and then binds them together under an aggregate LINQ expression.
     /// </summary>
     /// <param name="node">Current UCAST node in the conditions tree.</param>
-    /// <param name="parameter">LINQ data source (same type as <typeparamref name="T"/>).</param>
+    /// <param name="property">LINQ data source (usually same type as <typeparamref name="T"/>).</param>
     /// <param name="mapper">Dictionary mapping UCAST property names to lambdas that generate LINQ Expressions.</param>
     /// <returns>Result, an aggregate LINQ Expression.</returns>
-    private static Expression BuildFieldInExpression<T>(UCASTNode node, ParameterExpression parameter, MappingConfiguration<T> mapper)
+    private static Expression BuildFieldInExpression<T>(UCASTNode node, Expression property, MappingConfiguration<T> mapper)
     {
         if (node.Value is null)
         {
@@ -118,11 +169,30 @@ public static class QueryableExtensions
         };
         var childValues = (List<object>)node.Value;
 
-        IEnumerable<Expression> fieldChecks = new List<Expression>();
+
+        // Iterate over all children, and determine highest-precedent type among
+        // them. Convert LHS value if needed. RHS type conversions will happen
+        // automatically during expression building later.
+        Type lhsType = property.Type;
+        if (IsNumericType(lhsType))
+        {
+            IEnumerable<Type> childTypes = childValues.Select(x => Expression.Constant(x).Type);
+            var highestPrecedentType = lhsType;
+            foreach (var childType in childTypes)
+            {
+                highestPrecedentType = GetHigherPrecedenceNumericType(highestPrecedentType, childType);
+            }
+            if (lhsType != highestPrecedentType)
+            {
+                property = Expression.Convert(property, highestPrecedentType);
+            }
+        }
+
+        IEnumerable<Expression> fieldChecks = new List<Expression>(childValues.Count);
         foreach (var value in childValues)
         {
             eq.Value = value;
-            fieldChecks = fieldChecks.Append(BuildExpression<T>(eq, parameter, mapper));
+            fieldChecks = fieldChecks.Append(BuildFieldExpressionFromProperty(eq, property, mapper));
         }
 
         return fieldChecks.Aggregate(Expression.OrElse);

--- a/test/Styra.Ucast.Linq.Tests/UnitTest.cs
+++ b/test/Styra.Ucast.Linq.Tests/UnitTest.cs
@@ -337,9 +337,72 @@ public class UnitTestREADMEExample
     }
 }
 
+public class UnitTestTypeConversions
+{
+    public record IntRecord(int Value);
+    public record LongRecord(long Value);
+    public record FloatRecord(float Value);
+    public record DoubleRecord(double Value);
+    public UCASTNode conditions = new()
+    {
+        Type = "compound",
+        Op = "or",
+        Value = new List<UCASTNode>{
+            new() { Type = "field", Op = "ge", Field = "r.value", Value = 1500.0f },
+            new() { Type = "compound", Op = "and", Value = new List<UCASTNode>{
+                new() { Type = "field", Op = "lt", Field = "r.value", Value = 400L },
+                new() { Type = "compound", Op = "or", Value = new List<UCASTNode>{
+                    new() { Type = "field", Op = "gt", Field = "r.value", Value = 0 },
+                    new() { Type = "field", Op = "lt", Field = "r.value", Value = -1500.0d },
+                } },
+            } },
+        }
+    };
+
+    [Fact]
+    public void TestComparisonsVersusIntSource()
+    {
+        int[] numbers = [-1523, 1894, -456, 789, -1002, 345, -1789, 567, 1234, -890, 123, -1456, 1678, -234, 567, -1890, 901, -345, 1567, -789];
+        List<IntRecord> collection = [.. numbers.Select(n => new IntRecord(n))];
+        var expected = collection.Where(x => x.Value >= 1500.0f || (x.Value < 400L && (x.Value > 0 || x.Value < -1500.0d))).OrderBy(x => x.Value).ToList();
+        var result = collection.AsQueryable().ApplyUCASTFilter(conditions, new MappingConfiguration<IntRecord>(prefix: "r")).OrderBy(x => x.Value).ToList();
+        Assert.Equivalent(expected, result, true);
+    }
+
+    [Fact]
+    public void TestComparisonsVersusLongSource()
+    {
+        long[] numbers = [-1523, 1894, -456, 789, -1002, 345, -1789, 567, 1234, -890, 123, -1456, 1678, -234, 567, -1890, 901, -345, 1567, -789];
+        List<LongRecord> collection = [.. numbers.Select(n => new LongRecord(n))];
+        var expected = collection.Where(x => x.Value >= 1500.0f || (x.Value < 400L && (x.Value > 0 || x.Value < -1500.0d))).OrderBy(x => x.Value).ToList();
+        var result = collection.AsQueryable().ApplyUCASTFilter(conditions, new MappingConfiguration<LongRecord>(prefix: "r")).OrderBy(x => x.Value).ToList();
+        Assert.Equivalent(expected, result, true);
+    }
+
+    [Fact]
+    public void TestComparisonsVersusFloatSource()
+    {
+        float[] numbers = [-1523.0f, 1894.0f, -456.0f, 789.0f, -1002.0f, 345.0f, -1789.0f, 567.0f, 1234.0f, -890.0f, 123.0f, -1456.0f, 1678.0f, -234.0f, 567.0f, -1890.0f, 901.0f, -345.0f, 1567.0f, -789.0f];
+        List<FloatRecord> collection = [.. numbers.Select(n => new FloatRecord(n))];
+        var expected = collection.Where(x => x.Value >= 1500.0f || (x.Value < 400L && (x.Value > 0 || x.Value < -1500.0d))).OrderBy(x => x.Value).ToList();
+        var result = collection.AsQueryable().ApplyUCASTFilter(conditions, new MappingConfiguration<FloatRecord>(prefix: "r")).OrderBy(x => x.Value).ToList();
+        Assert.Equivalent(expected, result, true);
+    }
+
+    [Fact]
+    public void TestComparisonsVersusDoubleSource()
+    {
+        double[] numbers = [-1523.0d, 1894.0d, -456.0d, 789.0d, -1002.0d, 345.0d, -1789.0d, 567.0d, 1234.0d, -890.0d, 123.0d, -1456.0d, 1678.0d, -234.0d, 567.0d, -1890.0d, 901.0d, -345.0d, 1567.0d, -789.0d];
+        List<DoubleRecord> collection = [.. numbers.Select(n => new DoubleRecord(n))];
+        var expected = collection.Where(x => x.Value >= 1500.0f || (x.Value < 400L && (x.Value > 0 || x.Value < -1500.0d))).OrderBy(x => x.Value).ToList();
+        var result = collection.AsQueryable().ApplyUCASTFilter(conditions, new MappingConfiguration<DoubleRecord>(prefix: "r")).OrderBy(x => x.Value).ToList();
+        Assert.Equivalent(expected, result, true);
+    }
+}
+
 public class UnitTestMasking
 {
-    private static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
     private static readonly MappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(prefix: "data");
 
     [Fact]
@@ -388,7 +451,7 @@ public class UnitTestMasking
 
 public class UnitTestMaskingEFCore
 {
-    private static List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
+    private static readonly List<UnitTestDataSource.HydrologyData> testdata = UnitTestDataSource.GetTestHydrologyData();
     private static readonly EFCoreMappingConfiguration<UnitTestDataSource.HydrologyData> mapping = new(prefix: "data");
 
     [Fact]


### PR DESCRIPTION
## What changed?

This commit includes a substantial upgrade to numeric type conversion behavior, allowing the library to handle mixed numeric types across the full suite of UCAST operations we support.

This new system uses a concept of numeric type precedence, upcasting where needed to ensure no loss of precision during queries. The system also automatically figures out the highest-precedence numeric type in an `in`/`nin` expression, and then ensures both the field and values are all converted to the appropriate type in the LINQ Expression tree.