### PR TITLE
UCASTNode: Expose new constructor options for inheritors.

### DIFF
--- a/src/Styra.Ucast.Linq/QueryableExtensions.cs
+++ b/src/Styra.Ucast.Linq/QueryableExtensions.cs
@@ -161,12 +161,7 @@ public static class QueryableExtensions
         {
             throw new NullReferenceException();
         }
-        var eq = new UCASTNode
-        {
-            Type = "field",
-            Op = "eq",
-            Field = node.Field,
-        };
+        var eq = new UCASTNode("field", "eq", node.Field);
         var childValues = (List<object>)node.Value;
 
 

--- a/src/Styra.Ucast.Linq/UCASTNode.cs
+++ b/src/Styra.Ucast.Linq/UCASTNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -65,6 +66,22 @@ public class UCASTNode
     [JsonProperty("value")]
     [JsonConverter(typeof(UCASTNodeValueConverter))]
     public object? Value; // Either another string, or a List<UCASTNode>.
+
+    // This default constructor ensures we can still build UCASTNode types with
+    // object initializers, without losing the contract of the required members.
+    public UCASTNode() { }
+
+    // This embellished constructor is an escape hatch for inheriting types, so
+    // that they can invoke a base() constructor without exploding from the
+    // required members.
+    [SetsRequiredMembers]
+    public UCASTNode(string type, string op, string? field = null, object? value = null)
+    {
+        Type = type;
+        Op = op;
+        Field = field;
+        Value = value;
+    }
 }
 
 public class UCASTNodeValueConverter : JsonConverter


### PR DESCRIPTION
## What changed?

This PR includes explicit parameterless and fully parametrized constructors, allowing child classes to invoke the parameterized, or parameterless base constructor of this class to work around contract for the `required` members.

In particular, this would break before, because the base class init would explode from the `required` member init:
```csharp
public class MyUCASTNode : UCASTNode {
    public MyUCASTNode(string type, string op) : base() {
        Type = type;
        Op = op;
    }
}
```
The behavior was surprising, and not easy to work around.

You _could_ maybe work around that hiccup with the `[SetsRequiredMembers]` [property](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/required-members#setsrequiredmembersattribute) (which we actually do here for the parametrized constructor), but that's an ugly burden to foist on a class's children.

This PR _should_ fix the issue soundly, freeing up derived classes to go focus on other matters. The parameterless constructor moves the required member init burden up to the deriving class's constructor/object initialization blocks, while the parameterized constructor allows solving that same problem by parameter passing.

## Additional Resources

 - [C# Language Reference docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/required-members#setsrequiredmembersattribute) on the `[SetsRequiredMembers]` attribute for constructors.