### PR TITLE
ci: Add manual NuGet publishing flow for first-time publish.

### DIFF
--- a/.github/workflows/manual_publish_nuget_pkg.yaml
+++ b/.github/workflows/manual_publish_nuget_pkg.yaml
@@ -1,0 +1,54 @@
+name: "Manually Publish Package to NuGet"
+
+# This workflow is intended for populating the initial NuGet package.
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  NuGetDirectory: ${{ github.workspace }}/nuget
+
+jobs:
+  manual-build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Get all history for automatic versioning
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+
+      - name: Get current version
+        id: current_version
+        run: |
+          $currentVersion = (Select-Xml -Path src/OpenPolicyAgent.Ucast.Linq/OpenPolicyAgent.Ucast.Linq.csproj -XPath "//PackageVersion").Node.InnerText
+          echo "CURRENT_VERSION=$currentVersion" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+
+      - name: Pack
+        run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
+
+      - name: Publish NuGet package
+        run: |
+          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
+            dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }
+        shell: pwsh


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

To have the normal NuGet workflow succeed, we first have to populate the package up on NuGet. This new workflow solves that problem.

### :athletic_shoe: How to test

 - Merge PR. Test the new Manual workflow.

### :chains: Related Resources

